### PR TITLE
Fix unauthenticated http status code

### DIFF
--- a/app/Providers/ApiServiceProvider.php
+++ b/app/Providers/ApiServiceProvider.php
@@ -3,8 +3,10 @@
 namespace Someline\Providers;
 
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class ApiServiceProvider extends ServiceProvider
 {
@@ -18,6 +20,9 @@ class ApiServiceProvider extends ServiceProvider
         $handler = app('Dingo\Api\Exception\Handler');
         $handler->register(function (AuthorizationException $exception) {
             throw new AccessDeniedHttpException($exception->getMessage());
+        });
+        $handler->register(function (AuthenticationException $exception) {
+            throw new UnauthorizedHttpException(null, $exception->getMessage());
         });
     }
 


### PR DESCRIPTION
because of use the dingo api to handle the exception without registered the AuthenticationException
will return the `500` http status code,But what we expected is `401`

see in 
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Auth/Middleware/Authenticate.php#L66
```php
// Illuminate/Auth/Middleware/Authenticate
    ...
    /**
     * Determine if the user is logged in to any of the given guards.
     *
     * @param  array  $guards
     * @return void
     *
     * @throws \Illuminate\Auth\AuthenticationException
     */
    protected function authenticate(array $guards)
    {
        if (empty($guards)) {
            return $this->auth->authenticate();
        }
        foreach ($guards as $guard) {
            if ($this->auth->guard($guard)->check()) {
                return $this->auth->shouldUse($guard);
            }
        }
        throw new AuthenticationException('Unauthenticated.', $guards);
    }
```

If without Dingo Api, AuthenticationException will be handle by `Illuminate/Foundation/Exceptions/Handler.php`,which will call the methods `unauthenticated` in `app\Exceptions\Handler.php`
see
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Exceptions/Handler.php#L134

```php
// Illuminate/Foundation/Exceptions/Handler
    ...
    /**
     * Render an exception into a response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Exception  $e
     * @return \Symfony\Component\HttpFoundation\Response
     */
    public function render($request, Exception $e)
    {
        $e = $this->prepareException($e);
        if ($e instanceof HttpResponseException) {
            return $e->getResponse();
        } elseif ($e instanceof AuthenticationException) {
            return $this->unauthenticated($request, $e);
        } elseif ($e instanceof ValidationException) {
            return $this->convertValidationExceptionToResponse($e, $request);
        }
        return $this->prepareResponse($request, $e);
    }
```
```php
// app/Exception/Handle
    ...
    /**
     * Convert an authentication exception into an unauthenticated response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Illuminate\Auth\AuthenticationException  $exception
     * @return \Illuminate\Http\Response
     */
    protected function unauthenticated($request, AuthenticationException $exception)
    {
        if ($request->expectsJson()) {
            return response()->json(['error' => 'Unauthenticated.'], 401);
        }
        return redirect()->guest('login');
    }
```

So registered the AuthenticationException and return the correct http status code `401`



